### PR TITLE
Keep crontab outside of home

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a `./crontab` file:
 Run it!
 
 ``` sh
-docker run --rm --mount="type=bind,src=./crontab,dst=/worker/crontab" ghcr.io/2franix/cron-docker:latest
+docker run --rm --mount="type=bind,src=./crontab,dst=/crontab" ghcr.io/2franix/cron-docker:latest
 ```
 
 On the next minute, you should see in the output that it is working:
@@ -39,7 +39,7 @@ services:
     image: ghcr.io/2franix/cron-docker:latest
     restart: unless-stopped
     volumes:
-      - ./crontab:/worker/crontab
+      - ./crontab:/crontab
 ```
 
 See [the sample compose.yaml](examples/compose/compose.yaml) file in the examples folder.
@@ -51,13 +51,15 @@ At runtime, it installs the crontab file specified by the `CRON_SPEC_FILE` envir
 
 If you need additional scripts to run the job, the recommended way is to mount them in `worker`'s home directory (defaults to `/worker`, configurable via the `CRON_USER_HOME` environment variable). Doing so, the image guarantees that those file are owned by the `worker` user at runtime.
 
+Note that the mounted crontab is installed at startup, so modifying it while the container is running does not have any effect on cron.
+
 ## Environment variables in the image
 
-| Variable       | Default value     | Modifiable | Notes                                                                                                |
-|----------------|-------------------|------------|------------------------------------------------------------------------------------------------------|
-| CRON_USER      | "worker"          | no         | Set at build time, cannot be changed.                                                                |
-| CRON_USER_UID  | 1000              | yes        |                                                                                                      |
-| CRON_USER_GID  | 1000              | yes        |                                                                                                      |
-| CRON_USER_HOME | `/worker`         | yes        | See CRON_SPEC_FILE if you change this variable.                                                      |
-| CRON_SPEC_FILE | `/worker/crontab` | yes        | Contains the crontab definition, as expected by cron. Make sure to keep it under the home directory. |
-| CRON_VERBOSITY | 8                 | yes        | A value between 0 (max) and 8 (min) to control cron's verbosity.                                     |
+| Variable       | Default value | Modifiable | Notes                                                            |
+|----------------|---------------|------------|------------------------------------------------------------------|
+| CRON_USER      | "worker"      | no         | Set at build time, cannot be changed.                            |
+| CRON_USER_UID  | 1000          | yes        |                                                                  |
+| CRON_USER_GID  | 1000          | yes        |                                                                  |
+| CRON_USER_HOME | `/worker`     | yes        | See CRON_SPEC_FILE if you change this variable.                  |
+| CRON_SPEC_FILE | `/crontab`    | yes        | Contains the crontab definition, as expected by cron.            |
+| CRON_VERBOSITY | 8             | yes        | A value between 0 (max) and 8 (min) to control cron's verbosity. |

--- a/examples/compose/compose.yaml
+++ b/examples/compose/compose.yaml
@@ -3,12 +3,12 @@ services:
     image: ghcr.io/2franix/cron-docker:latest
     restart: unless-stopped
     volumes:
-      - ./crontab:/worker/crontab # Adjust if you change CRON_USER_HOME or CRON_SPEC_FILE below.
+      - ./crontab:/crontab # Adjust if you change CRON_USER_HOME or CRON_SPEC_FILE below.
     environment:
       # Those are only displayed here to document their default values as set in the image.
       # You should not define them explicitly unless you want to change the values.
       CRON_USER_UID: 1000 # Id of the user running the cron job.
       CRON_USER_GID: 1000 # Primary group id of the user running the cron job.
       CRON_USER_HOME: /worker # Home directory for the user running the cron job.
-      CRON_SPEC_FILE: /worker/crontab # Make sure to keep the file under the user home to avoid permission issues.
+      CRON_SPEC_FILE: /crontab # Location of the cron job specification file.
       CRON_VERBOSITY: 8 # 0-8, 0 is maximum verbosity, 8 is minimum.

--- a/examples/docker/run_example.sh
+++ b/examples/docker/run_example.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-docker run --rm --mount="type=bind,src=./crontab,dst=/worker/crontab ghcr.io/2franix/cron-docker:latest"
+docker run --rm --mount="type=bind,src=./crontab,dst=/worker/crontab" ghcr.io/2franix/cron-docker:latest


### PR DESCRIPTION
Having it in home causes its permissions to be changed. This is not useful, so just keep it out of home by default.